### PR TITLE
Fixed bug in interfaces.py

### DIFF
--- a/B1Py/interfaces.py
+++ b/B1Py/interfaces.py
@@ -156,7 +156,7 @@ class B1HighLevelReal:
         col_fr_rr = hppfcl.collide(
             self.fr_cylinder_hppfcl, T_fr, self.rr_cylinder_hppfcl, T_rr, req, res
         )
-        in_collision = np.all(
+        in_collision = np.any(
             [col_fl_rl, col_fl_fr, col_fl_rr, col_rl_fr, col_rl_rr, col_fr_rr]
         )
 

--- a/examples/self_collision_test.py
+++ b/examples/self_collision_test.py
@@ -146,7 +146,6 @@ if __name__ == "__main__":
         )
 
         print(in_collision)
-        # breakpoint()
 
         p.resetBasePositionAndOrientation(
             fl_cylinder,


### PR DESCRIPTION
Updated collision check to use `np.any()` instead of `np.all()`.